### PR TITLE
fix: rename artwork entity and update imports

### DIFF
--- a/src/controllers/artwork.controller.ts
+++ b/src/controllers/artwork.controller.ts
@@ -18,7 +18,7 @@ import { Token } from 'src/auth/token';
 import { DeleteStatus } from 'src/commons/enums/delete-status.enum';
 import { CreateArtworkDto } from 'src/models/dto/create-artwork.dto';
 import { UpdateArtworkDto } from 'src/models/dto/update-artwork.dto';
-import { Artwork } from 'src/models/entities/atrwork.entity';
+import { Artwork } from 'src/models/entities/artwork.entity';
 import { ArtworkService } from 'src/services/artwork/artwork.service';
 
 @Controller('artworks')

--- a/src/models/dto/create-artwork.dto.ts
+++ b/src/models/dto/create-artwork.dto.ts
@@ -1,4 +1,4 @@
 import { PickType } from '@nestjs/swagger';
-import { Artwork } from '../entities/atrwork.entity';
+import { Artwork } from '../entities/artwork.entity';
 
 export class CreateArtworkDto extends PickType(Artwork, ['title', 'description']) {}

--- a/src/models/entities/artwork.entity.ts
+++ b/src/models/entities/artwork.entity.ts
@@ -35,11 +35,9 @@ export class Artwork {
   )
   exhibitions: ExhibitionArtwork[];
 
-  @Column()
   @CreateDateColumn()
   created_at: Date;
 
-  @Column()
   @UpdateDateColumn()
   updated_at: Date;
 }

--- a/src/models/entities/exhibition-artwork.entity.ts
+++ b/src/models/entities/exhibition-artwork.entity.ts
@@ -1,6 +1,6 @@
 import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
 import { Exhibition } from './exhibition.entity';
-import { Artwork } from './atrwork.entity';
+import { Artwork } from './artwork.entity';
 
 @Entity()
 export class ExhibitionArtwork {

--- a/src/models/entities/exhibition.entity.ts
+++ b/src/models/entities/exhibition.entity.ts
@@ -1,6 +1,6 @@
 import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
 import { User } from './user.entity';
-import { Artwork } from './atrwork.entity';
+import { Artwork } from './artwork.entity';
 import { ExhibitionArtwork } from './exhibition-artwork.entity';
 
 @Entity()

--- a/src/models/entities/user.entity.ts
+++ b/src/models/entities/user.entity.ts
@@ -1,6 +1,6 @@
 import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 import { Exhibition } from "./exhibition.entity";
-import { Artwork } from "./atrwork.entity";
+import { Artwork } from "./artwork.entity";
 
 @Entity()
 export class User {

--- a/src/services/artwork/artwork.module.ts
+++ b/src/services/artwork/artwork.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ArtworkController } from 'src/controllers/artwork.controller';
-import { Artwork } from 'src/models/entities/atrwork.entity';
+import { Artwork } from 'src/models/entities/artwork.entity';
 import { ArtworkService } from './artwork.service';
 import { S3Service } from 'configs/s3/s3.service';
 import { JwtStrategy } from 'src/auth/jwt/jwt.strategy';

--- a/src/services/artwork/artwork.service.ts
+++ b/src/services/artwork/artwork.service.ts
@@ -4,7 +4,7 @@ import { S3Service } from 'configs/s3/s3.service';
 import { DeleteStatus } from 'src/commons/enums/delete-status.enum';
 import { CreateArtworkDto } from 'src/models/dto/create-artwork.dto';
 import { UpdateArtworkDto } from 'src/models/dto/update-artwork.dto';
-import { Artwork } from 'src/models/entities/atrwork.entity';
+import { Artwork } from 'src/models/entities/artwork.entity';
 import { User } from 'src/models/entities/user.entity';
 import { Repository } from 'typeorm';
 

--- a/src/services/exhibition-artwork/exhibition-artwork.module.ts
+++ b/src/services/exhibition-artwork/exhibition-artwork.module.ts
@@ -6,7 +6,7 @@ import { ExhibitionArtworkService } from "./exhibition-artwork.service";
 import { PassportModule } from "@nestjs/passport";
 import { JwtStrategy } from "src/auth/jwt/jwt.strategy";
 import { Exhibition } from "src/models/entities/exhibition.entity";
-import { Artwork } from "src/models/entities/atrwork.entity";
+import { Artwork } from "src/models/entities/artwork.entity";
 
 @Module({
   imports: [

--- a/src/services/exhibition-artwork/exhibition-artwork.service.ts
+++ b/src/services/exhibition-artwork/exhibition-artwork.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { CreateExhibitionArtworkDto } from "src/models/dto/create-exhibition-artwork.dto";
-import { Artwork } from "src/models/entities/atrwork.entity";
+import { Artwork } from "src/models/entities/artwork.entity";
 import { ExhibitionArtwork } from "src/models/entities/exhibition-artwork.entity";
 import { Exhibition } from "src/models/entities/exhibition.entity";
 import { In, Repository } from "typeorm";


### PR DESCRIPTION
## Summary
- rename misnamed `atrwork.entity.ts` to `artwork.entity.ts`
- remove extra `@Column` decorators from timestamp fields
- update DTOs, controllers, and services to import the new entity path

## Testing
- `npm test` *(fails: No tests found)*
- `npm run build`
- `node dist/src/main.js` *(fails: JwtStrategy requires a secret or key)*

------
https://chatgpt.com/codex/tasks/task_e_68b466b272a88323ba6288509138a9ac